### PR TITLE
Allow multiple check commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -559,9 +559,10 @@ the log files for easier searching of error/warning messages.
 
 * **check_cmd** Unset by default
 
-The command to run to determine the status of the service based
-**on the return code**. Complex health checking should be wrapped in a script.
-When check command fails, the stdout and stderr appears in the log file.
+A comma separated list of commands to run to determine the status of the service
+based **on the return code**. Service is considered healthy if all commands
+succeed. Complex health checking should be wrapped in a script.
+When any check command fails, the stdout and stderr appears in the log file.
 
 * **check_interval** Defaults to **2** (seconds)
 

--- a/anycast_healthchecker/utils.py
+++ b/anycast_healthchecker/utils.py
@@ -391,17 +391,18 @@ def service_configuration_check(config):
                              "prefix configured for {name} service check"
                              .format(name=service))
 
-        cmd = shlex.split(config.get(service, 'check_cmd'))
-        try:
-            proc = subprocess.Popen(cmd)
-            proc.kill()
-        except (OSError, subprocess.SubprocessError) as exc:
-            msg = ("failed to run check command '{cmd}' for service check "
-                   "{name}: {err}"
-                   .format(name=service,
-                           cmd=config.get(service, 'check_cmd'),
-                           err=exc))
-            raise ValueError(msg)
+        for command in config.get(service, 'check_cmd').split(','):
+            cmd = shlex.split(command.strip())
+            try:
+                proc = subprocess.Popen(cmd)
+                proc.kill()
+            except (OSError, subprocess.SubprocessError) as exc:
+                msg = ("failed to run check command '{cmd}' for service check "
+                       "{name}: {err}"
+                       .format(name=service,
+                               cmd=command.strip(),
+                               err=exc))
+                raise ValueError(msg)
 
 
 def build_bird_configuration(config):


### PR DESCRIPTION
In some case there is a need to run multiple check commands to make
sure all the services behind single IP address are operational.
Now we can provide those checks as a comma separated list eg.

check_cmd = /usr/bin/command1 arg1 arg1, /usr/bin/command2 arg3 arg4