### PR TITLE
Set an interface on each check.conf file in puppet

### DIFF
--- a/contrib/puppet/anycast_healthchecker/manifests/check.pp
+++ b/contrib/puppet/anycast_healthchecker/manifests/check.pp
@@ -6,6 +6,9 @@
 
 # === Parameters:
 #
+# [*interface*] <string>               - Interface that the service IP resides on.
+#                                        Defaults to 'lo'.
+#
 # [*check_cmd*] <string>               - Full path of the command to run for
 #                                        healthchecking the service.
 #
@@ -58,14 +61,15 @@
 # Pavlos Parissis <pavlos.parissis@gmail.com>
 #
 define anycast_healthchecker::check (
-  $check_cmd         = '/bin/false',
-  $check_interval    = 10,
-  $check_timeout     = 5,
-  $check_rise        = 2,
-  $check_fail        = 2,
-  $check_disabled    = false,
-  $on_disabled       = "withdraw",
-  $ip_check_disabled = false,
+  String[1] $interface = 'lo',
+  $check_cmd           = '/bin/false',
+  $check_interval      = 10,
+  $check_timeout       = 5,
+  $check_rise          = 2,
+  $check_fail          = 2,
+  $check_disabled      = false,
+  $on_disabled         = "withdraw",
+  $ip_check_disabled   = false,
   $ip_prefix,
   ) {
 

--- a/contrib/puppet/anycast_healthchecker/templates/check.conf.erb
+++ b/contrib/puppet/anycast_healthchecker/templates/check.conf.erb
@@ -1,5 +1,5 @@
 [<%= @name%>]
-interface = <%= @name %>
+interface = <%= @interface %>
 check_cmd = <%= @check_cmd%>
 check_interval = <%= @check_interval%>
 check_timeout = <%= @check_timeout%>

--- a/contrib/puppet/anycast_healthchecker/templates/check.conf.erb
+++ b/contrib/puppet/anycast_healthchecker/templates/check.conf.erb
@@ -1,4 +1,5 @@
 [<%= @name%>]
+interface = <%= @name %>
 check_cmd = <%= @check_cmd%>
 check_interval = <%= @check_interval%>
 check_timeout = <%= @check_timeout%>


### PR DESCRIPTION
As written, `contrib/puppet/anycast_healthchecker/templates/check.conf.erb` has a hidden limitation that it always assumes you've put anycast on the `lo` interface, which is semi-reasonable because it's a common default and that's what `anycast-healthchecker.conf` says.

This comes into play if you move your anycast off `lo` and off to, say, `anycast0`.  `anycast_healthchecker/servicecheck.py` : `_ip_assigned` looks for `dev self.config['interface']` ... which always falls back to `lo`, and without this change to `check.conf` you are stuck.