### PR TITLE
Add support for exporting Prometheus metrics 

### DIFF
--- a/anycast_healthchecker/__init__.py
+++ b/anycast_healthchecker/__init__.py
@@ -8,6 +8,8 @@ __version__ = '0.9.1'
 __copyright__ = 'Copyright 2015-2020 Pavlos Parissis'
 
 PROGRAM_NAME = __title__.replace('_', '-')
+METRIC_PREFIX = __title__
+
 
 DEFAULT_OPTIONS = {
     'DEFAULT': {
@@ -45,5 +47,8 @@ DEFAULT_OPTIONS = {
         'json_log_server': 'false',
         'log_maxbytes': 104857600,
         'log_backups': 8,
+        'prometheus_exporter': 'false',
+        'prometheus_collector_textfile_dir': '/var/cache/textfile_collector/'
+
     }
 }

--- a/anycast_healthchecker/servicecheck.py
+++ b/anycast_healthchecker/servicecheck.py
@@ -35,7 +35,9 @@ class ServiceCheck(Thread):
 
     """
 
-    def __init__(self, service, config, action, splay_startup):
+    def __init__(self, service, config, action, splay_startup, metric_state,
+                 metric_check_duration, metric_check_ip_assignment,
+                 metric_check_timeout):
         """Set the name of thread to be the name of the service."""
         super(ServiceCheck, self).__init__()
         self.name = service  # Used by Thread()
@@ -85,6 +87,15 @@ class ServiceCheck(Thread):
         )
         self.log.info("loading check for %s", self.name, extra=self.extra)
 
+        self.metric_state = metric_state
+        self.metric_check_duration = metric_check_duration
+        self.metric_check_ip_assignment = metric_check_ip_assignment
+        self.metric_check_timeout = metric_check_timeout
+        self.labels = {
+            "service_name": self.name,
+            "ip_prefix": self.ip_with_prefixlen
+        }
+
     def _run_check(self):
         """Execute a check command.
 
@@ -102,6 +113,7 @@ class ServiceCheck(Thread):
             outs, errs = proc.communicate(timeout=self.config['check_timeout'])
         except subprocess.TimeoutExpired:
             self.log.error("check timed out")
+            self.metric_check_timeout.labels(**self.labels).inc()
             if proc.poll() is None:
                 try:
                     proc.kill()
@@ -112,9 +124,10 @@ class ServiceCheck(Thread):
 
             return False
         else:
-            msg = "check duration {t:.3f}ms".format(
-                t=(time.time() - start_time) * 1000)
+            duration = (time.time() - start_time) * 1000
+            msg = "check duration {t:.3f}ms".format(t=duration)
             self.log.info(msg)
+            self.metric_check_duration.labels(**self.labels).set(duration)
 
             if proc.returncode != 0:
                 self.log.info("stderr from the check %s", errs)
@@ -139,11 +152,12 @@ class ServiceCheck(Thread):
             'to',
             self.ip_with_prefixlen,
         ]
+        result = False
 
         if self.ip_check_disabled:
             self.log.info("checking for IP assignment on interface %s is "
                           "disabled", self.config['interface'])
-            return True
+            result = True
 
         self.log.debug("running %s", ' '.join(cmd))
         try:
@@ -155,11 +169,11 @@ class ServiceCheck(Thread):
             self.log.error("error checking IP-PREFIX %s: %s",
                            cmd, error.output)
             # Because it is unlikely to ever get an error we return True
-            return True
+            result = True
         except subprocess.TimeoutExpired:
             self.log.error("timeout running %s", ' '.join(cmd))
             # Because it is unlikely to ever get a timeout we return True
-            return True
+            result = True
         except ValueError as error:
             # We have been getting intermittent ValueErrors, see here
             # gist.github.com/unixsurfer/67db620d87f667423f6f6e3a04e0bff5
@@ -174,23 +188,26 @@ class ServiceCheck(Thread):
             # know. A retry logic could be a more proper solution.
             self.log.error("running %s raised ValueError exception:%s",
                            ' '.join(cmd), error)
-            return True
+            result = True
         else:
             if self.ip_with_prefixlen in output:  # pylint: disable=E1135,R1705
                 msg = "{i} assigned to loopback interface".format(
                     i=self.ip_with_prefixlen)
                 self.log.debug(msg)
-                return True
+                result = True
             else:
                 msg = ("{i} isn't assigned to {d} interface"
                        .format(i=self.ip_with_prefixlen,
                                d=self.config['interface']))
                 self.log.warning(msg)
-                return False
+                result = False
 
-        self.log.debug("I shouldn't land here!, it is a BUG")
+        if result:
+            self.metric_check_ip_assignment.labels(**self.labels).set(1)
+        else:
+            self.metric_check_ip_assignment.labels(**self.labels).set(0)
 
-        return False
+        return result
 
     def _check_disabled(self):
         """Check if health check is disabled.
@@ -273,6 +290,7 @@ class ServiceCheck(Thread):
                                  "loopback interface.",
                                  self.ip_with_prefixlen,
                                  extra=self.extra)
+                self.metric_state.labels(**self.labels).set(0)
                 if check_state != 'DOWN':
                     check_state = 'DOWN'
                     self.log.info("adding %s in the queue",
@@ -283,6 +301,7 @@ class ServiceCheck(Thread):
                 if up_cnt == (self.config['check_rise'] - 1):
                     self.extra['status'] = 'up'
                     self.log.info("status UP", extra=self.extra)
+                    self.metric_state.labels(**self.labels).set(1)
                     # Service exceeded all consecutive checks. Set its state
                     # accordingly and put an item in queue. But do it only if
                     # previous state was different, to prevent unnecessary bird
@@ -310,6 +329,7 @@ class ServiceCheck(Thread):
                     # But do it only if previous state was different, to
                     # prevent unnecessary bird reloads when a service flaps
                     # between states
+                    self.metric_state.labels(**self.labels).set(0)
                     if check_state != 'DOWN':
                         check_state = 'DOWN'
                         self.log.info("adding %s in the queue",


### PR DESCRIPTION
This PR adds support for exporting statistics that are compatible with Prometheus monitoring system
 
We don't expose any HTTP interface, we simply write the metrics to a file and users need to use [texfile collector](https://github.com/prometheus/node_exporter#textfile-collector) of node_exporter in order to forward them to Prometheus.

Below is an example of `anycast.prom` file that exposes the statistics.
```
# HELP anycast_healthchecker_service_state The status of the service check: 0 = down, 1 = up
# TYPE anycast_healthchecker_service_state gauge
anycast_healthchecker_service_state{ip_prefix="fd12:aba6:57db:ffff::1/128",service_name="foo1IPv6.bar.com"} 0.0
anycast_healthchecker_service_state{ip_prefix="10.52.12.1/32",service_name="foo.bar.com"} 0.0
anycast_healthchecker_service_state{ip_prefix="10.52.12.2/32",service_name="foo1.bar.com"} 0.0
# HELP anycast_healthchecker_service_check_duration_milliseconds Service check duration in milliseconds
# TYPE anycast_healthchecker_service_check_duration_milliseconds gauge
anycast_healthchecker_service_check_duration_milliseconds{ip_prefix="10.52.12.1/32",service_name="foo.bar.com"} 5.141496658325195
# HELP anycast_healthchecker_service_check_ip_assignment Service IP assignment check: 0 = not aissgned, 1 = assigned
# TYPE anycast_healthchecker_service_check_ip_assignment gauge
anycast_healthchecker_service_check_ip_assignment{ip_prefix="10.52.12.1/32",service_name="foo.bar.com"} 1.0
anycast_healthchecker_service_check_ip_assignment{ip_prefix="fd12:aba6:57db:ffff::1/128",service_name="foo1IPv6.bar.com"} 0.0
anycast_healthchecker_service_check_ip_assignment{ip_prefix="10.52.12.2/32",service_name="foo1.bar.com"} 1.0
# HELP anycast_healthchecker_service_check_timeout_total The number of times a service check timed out
# TYPE anycast_healthchecker_service_check_timeout_total counter
anycast_healthchecker_service_check_timeout_total{ip_prefix="10.52.12.2/32",service_name="foo1.bar.com"} 3.0
# HELP anycast_healthchecker_service_check_timeout_created The number of times a service check timed out
# TYPE anycast_healthchecker_service_check_timeout_created gauge
anycast_healthchecker_service_check_timeout_created{ip_prefix="10.52.12.2/32",service_name="foo1.bar.com"} 1.698693786243282e+09
# HELP anycast_healthchecker_uptime Uptime of the process in seconds since the epoch
# TYPE anycast_healthchecker_uptime gauge
anycast_healthchecker_uptime 1.6986938162371802e+09
# HELP anycast_healthchecker_state The current state of the process: 0 = down, 1 = up
# TYPE anycast_healthchecker_state gauge
anycast_healthchecker_state 1.0
# HELP anycast_healthchecker_version_info Version of the software
# TYPE anycast_healthchecker_version_info gauge
anycast_healthchecker_version_info{version="0.9.1"} 1.0
# HELP anycast_healthchecker_service The configured service checks
# TYPE anycast_healthchecker_service gauge
anycast_healthchecker_service{ip_prefix="10.52.12.1/32",service_name="foo.bar.com"} 1.0
anycast_healthchecker_service{ip_prefix="fd12:aba6:57db:ffff::1/128",service_name="foo1IPv6.bar.com"} 1.0
anycast_healthchecker_service{ip_prefix="10.52.12.2/32",service_name="foo1.bar.com"} 1.0
```