### PR TITLE
Make sure the process shutdowns cleanly

### DIFF
--- a/anycast_healthchecker/utils.py
+++ b/anycast_healthchecker/utils.py
@@ -1266,6 +1266,7 @@ class MainExporter(Thread):
     def __init__(self, registry, services, config):
         """Set the name of thread to be the name of the service."""
         super(MainExporter, self).__init__()
+        self.daemon = True
         self.registry = registry
         self.uptime = Gauge(
             name='uptime',


### PR DESCRIPTION
With https://github.com/unixsurfer/anycast_healthchecker/commit/fb2fda1a3624733631a545f20e5bd353c68a3d1d we introduced a regression which made the process to not stop all threads during the shutdown process.
This caused systemd to report time out errors:
```
14:27:04 systemd[1]: Stopping Anycast healthchecker...
14:28:34 systemd[1]: anycast-healthchecker.service: State 'stop-sigterm' timed out. Killing.
14:28:34 systemd[1]: anycast-healthchecker.service: Killing process 1105605 (anycast-healthc) with signal SIGKILL.
14:28:34 systemd[1]: anycast-healthchecker.service: Killing process 1105628 (anycast-healthc) with signal SIGKILL.
14:28:34 systemd[1]: anycast-healthchecker.service: Killing process 1105629 (anycast-healthc) with signal SIGKILL.
14:28:34 systemd[1]: anycast-healthchecker.service: Killing process 1105631 (anycast-healthc) with signal SIGKILL.
14:28:34 systemd[1]: anycast-healthchecker.service: Main process exited, code=killed, status=9/KILL
14:28:34 systemd[1]: anycast-healthchecker.service: Failed with result 'timeout'.
14:28:34 systemd[1]: Stopped Anycast healthchecker.
```
systemd notices that not all threads are stopped and after 90s (default value for TimeoutStopSec) it sends the KILL signal.

This was caused by not setting the thread for Prometheus exporter as a daemon thread.