### PR TITLE
 Customize the interval that Prometheus exporters runs 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,6 +243,7 @@ anycast-healthchecker uses the popular `INI`_ format for its configuration files
     json_log_server       = false
     prometheus_exporter   = false
     prometheus_collector_textfile_dir = /var/cache/textfile_collector/
+    prometheus_exporter_interval      = 20
 
 The above settings are used as defaults when anycast-healthchecker is launched without a configuration file. anycast-healthchecker **does not** need to run as root as long as it has sufficient privileges to modify the Bird configuration set in ``bird_conf`` or ``bird6_conf``, and trigger a reconfiguration of Bird by running the command configured in ``bird_reconfigure_cmd`` or ``bird6_reconfigure_cmd``. In the above example ``sudo`` is used for that purpose (``sudoers`` file has been modified for that purpose).
 
@@ -386,6 +387,10 @@ syslog server.
 * **prometheus_collector_textfile_dir** Defaults to **/var/cache/textfile_collector/**
 
 The directory to store the exported statistics.
+
+* **prometheus_exporter_interval** Defaults to **20** seconds
+
+How often to export Prometheus metrics.
 
 * **splay_startup** Unset by default
 

--- a/anycast_healthchecker/__init__.py
+++ b/anycast_healthchecker/__init__.py
@@ -48,7 +48,8 @@ DEFAULT_OPTIONS = {
         'log_maxbytes': 104857600,
         'log_backups': 8,
         'prometheus_exporter': 'false',
-        'prometheus_collector_textfile_dir': '/var/cache/textfile_collector/'
+        'prometheus_collector_textfile_dir': '/var/cache/textfile_collector/',
+        'prometheus_exporter_interval': 10,
 
     }
 }

--- a/anycast_healthchecker/utils.py
+++ b/anycast_healthchecker/utils.py
@@ -1299,7 +1299,7 @@ class MainExporter(Thread):
         self.config = config
 
     def run(self):
-        """Wrap _run method."""
+        """The run method."""
 
         textfile = os.path.join(
             self.config.get(

--- a/anycast_healthchecker/utils.py
+++ b/anycast_healthchecker/utils.py
@@ -76,6 +76,7 @@ DAEMON_OPTIONS_TYPE = {
     'splay_startup': 'getfloat',
     'prometheus_exporter': 'getboolean',
     'prometheus_collector_textfile_dir': 'get',
+    'prometheus_exporter_interval': 'getint',
 }
 DAEMON_OPTIONAL_OPTIONS = [
     'stderr_log_server',
@@ -1307,7 +1308,7 @@ class MainExporter(Thread):
             "anycast_healthchecker.prom",
         )
         log = logging.getLogger(PROGRAM_NAME)
-        interval = 10
+        interval = self.config.getint('daemon', 'prometheus_exporter_interval')
         start_offset = time.time() % interval
         # Go in a loop until we are told to stop
         while True:

--- a/anycast_healthchecker/utils.py
+++ b/anycast_healthchecker/utils.py
@@ -1268,6 +1268,7 @@ class MainExporter(Thread):
         """Set the name of thread to be the name of the service."""
         super(MainExporter, self).__init__()
         self.daemon = True
+        self.name = 'PrometheusExporter'
         self.registry = registry
         self.uptime = Gauge(
             name='uptime',


### PR DESCRIPTION
Users can now adjust the interval that we export metrics by setting `prometheus_exporter_interval` parameters.

This PR also set the thread name to `PrometheusExporter` for the thread that exports metrics and adjust slightly the docstring of `run` method. 