### PR TITLE
Require setuptools 61+ for [project] metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ version = {attr = "anycast_healthchecker.__version__"}
 readme = {file = ["README.rst"]}
 
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Older setuptools versions will package this as UNKNOWN-0.0.0 witch no files in the package.

Only setuptools 61.0.0 added support for pyproject.toml configuration (as introduced by PEP 621).
https://setuptools.pypa.io/en/latest/history.html#v61-0-0 https://peps.python.org/pep-0621/