### PR TITLE
Restore setup.cfg and setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,37 @@
+[metadata]
+name = anycast-healthchecker
+author = Pavlos Parissis
+author-email = pavlos.parissis@gmail.com
+maintainer = Pavlos Parissis
+maintainer-email = pavlos.parissis@gmail.com
+summary = A healthchecker for Anycasted Services
+home-page = https://github.com/unixsurfer/anycast_healthchecker
+license = Apache 2.0
+classifier =
+    Development Status :: 5 - Production/Stable
+        Environment :: Console
+        Intended Audience :: Information Technology
+        Intended Audience :: System Administrators
+        Natural Language :: English
+        Operating System :: POSIX
+        Programming Language :: Python :: 3.4
+        Programming Language :: Python :: 3.5
+        Topic :: System :: Monitoring
+        Topic :: Utilities
+requires-dist =
+    python-json-logger
+    docopt
+    prometheus_client
+keywords = healthchecker anycast ECMP
+
+[files]
+packages =
+    anycast_healthchecker
+    anycast
+    healthchecker
+    Equal-Cost Multi-Pathing
+    monitor
+
+[entry_points]
+console_scripts =
+     anycast-healthchecker = anycast_healthchecker.main:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)


### PR DESCRIPTION
Building packages on OS versions that don't come with recent version(>61) setuptools is impossible thus we must restore setup.py and setup.cfg.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2250185#c1