### PR TITLE
Run all checks with a signal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -608,12 +608,20 @@ You can launch it by supplying a configuration file and a directory with configu
 
 At the root of the project there is System V init and a Systemd unit file for proper integration with OS startup tools.
 
+Sending a ``SIGURG`` signal to a running anycast-healthchecker process will trigger an immediate, additional (not changing the interval) execution of all active checks. This can be used to make external events faster rise/fail checks and thus announce/remove IPs, for example when some process dies. Note that the ``check_rise`` and ``check_fail`` options still apply.
+
 Systemd and SysVinit integration
 ################################
 
 Under contrib/systemd and contrib/SysVinit directories there are the necessary startup files that can be used to start anycast-healthchecker on boot.
 
 **IMPORTANT:** Version 0.8.0 dropped support for daemonization and therefore you can't use the System V init script stored under contrib/SysVinit directory with newer versions. If you want to use version 0.8.0 and higher on Operating Systems that don't support Systemd then you have to use a tool like supervisord.
+
+The following snippet/drop-in can be used on a monitored systemd service to make its start and stop (including due to failure) trigger an immediate check run::
+
+    [Service]
+    ExecStartPost=-/usr/bin/systemctl --system kill --signal=SIGURG anycast-healthchecker.service
+    ExecStopPost=-/usr/bin/systemctl --system kill --signal=SIGURG anycast-healthchecker.service
 
 Nagios check
 ############

--- a/README.rst
+++ b/README.rst
@@ -608,7 +608,7 @@ You can launch it by supplying a configuration file and a directory with configu
 
 At the root of the project there is System V init and a Systemd unit file for proper integration with OS startup tools.
 
-Sending a ``SIGURG`` signal to a running anycast-healthchecker process will trigger an immediate, additional (not changing the interval) execution of all active checks. This can be used to make external events faster rise/fail checks and thus announce/remove IPs, for example when some process dies. Note that the ``check_rise`` and ``check_fail`` options still apply.
+Sending a ``SIGURG`` signal to a running anycast-healthchecker process will trigger an immediate, additional (not changing the regular interval) execution of all active checks. For services with ``check_rise`` and/or ``check_fail`` set to ``1``, this can be used to make external events faster advertise and/or withdraw their prefixes.
 
 Systemd and SysVinit integration
 ################################
@@ -616,12 +616,6 @@ Systemd and SysVinit integration
 Under contrib/systemd and contrib/SysVinit directories there are the necessary startup files that can be used to start anycast-healthchecker on boot.
 
 **IMPORTANT:** Version 0.8.0 dropped support for daemonization and therefore you can't use the System V init script stored under contrib/SysVinit directory with newer versions. If you want to use version 0.8.0 and higher on Operating Systems that don't support Systemd then you have to use a tool like supervisord.
-
-The following snippet/drop-in can be used on a monitored systemd service to make its start and stop (including due to failure) trigger an immediate check run::
-
-    [Service]
-    ExecStartPost=-/usr/bin/systemctl --system kill --signal=SIGURG anycast-healthchecker.service
-    ExecStopPost=-/usr/bin/systemctl --system kill --signal=SIGURG anycast-healthchecker.service
 
 Nagios check
 ############

--- a/anycast_healthchecker/main.py
+++ b/anycast_healthchecker/main.py
@@ -94,6 +94,11 @@ def main():
 
     # Create our master process.
     checker = healthchecker.HealthChecker(config, bird_configuration)
+
+    # Register our SIGURG handler to immediately trigger all checks.
+    signal.signal(signal.SIGURG, lambda signum, frame: checker.run_all_checks_now())
+
+    # and start working
     logger.info("starting %s version %s", PROGRAM_NAME, __version__)
     checker.run()
 

--- a/anycast_healthchecker/servicecheck.py
+++ b/anycast_healthchecker/servicecheck.py
@@ -37,7 +37,7 @@ class ServiceCheck(Thread):
 
     def __init__(self, service, config, action, splay_startup, metric_state,
                  metric_check_duration, metric_check_ip_assignment,
-                 metric_check_timeout):
+                 metric_check_timeout, urgent_event):
         """Set the name of thread to be the name of the service."""
         super(ServiceCheck, self).__init__()
         self.name = service  # Used by Thread()
@@ -85,6 +85,7 @@ class ServiceCheck(Thread):
             bird_reconfigure_cmd=config.get('custom_bird_reconfigure_cmd',
                                             None)
         )
+        self.urgent_event = urgent_event
         self.log.info("loading check for %s", self.name, extra=self.extra)
 
         self.metric_state = metric_state
@@ -365,4 +366,4 @@ class ServiceCheck(Thread):
             if sleep < 0:
                 sleep += interval
             self.log.debug("sleeping for %.3fsecs", sleep, extra=self.extra)
-            time.sleep(sleep)
+            self.urgent_event.wait(timeout=sleep)


### PR DESCRIPTION
I am quoting the included README addition, since it already describes the feature pretty well (if you don't mind me saying so myself):

> Sending a ``SIGURG`` signal to a running anycast-healthchecker process will trigger an immediate, additional (not changing the interval) execution of all active checks. This can be used to make external events faster rise/fail checks and thus announce/remove IPs, for example when some process dies. Note that the ``check_rise`` and ``check_fail`` options still apply.

I use this primarily to have anycast_healthchecker faster de-announced the IP of a stopped or failed systemd service without having a very small `check_interval`. Assuming `check_fail` 1, even with a `check_interval` of 30 or 60: A few milliseconds after the systemd service stops/fails, the signal is sent, the check fails, and the IP is de-announced.

I choose `SIGURG` because it's not really used, even less so for it's intended purpose; and the name fits quite nicely here. It could easily be changed to `SIGUSR1`, or even one of the user-defined/real-time signals like `SIGRTMIN+1`.