### PR TITLE
Add prometheus-client to the requirements.txt file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ classifiers = [
 ]
 dynamic = ["version", "readme"]
 dependencies = [
-    "python-json-logger",
     "docopt",
-    "prometheus_client",
+    "prometheus-client",
+    "python-json-logger",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docopt
+prometheus-client
 python-json-logger

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ classifier =
         Topic :: System :: Monitoring
         Topic :: Utilities
 install_requires =
-    python-json-logger
     docopt
-    prometheus_client
+    prometheus-client
+    python-json-logger
 keywords = healthchecker anycast ECMP
 
 [files]


### PR DESCRIPTION
Additionally:
 * use pypi name for the prometheus client module (setup.cfg and pyproject.toml)
 * sort list of requirements (setup.cfg and pyproject.toml)