### PR TITLE
Honor appropriately the value of ip_check_disabled

### DIFF
--- a/anycast_healthchecker/servicecheck.py
+++ b/anycast_healthchecker/servicecheck.py
@@ -163,7 +163,7 @@ class ServiceCheck(Thread):
         if self.ip_check_disabled:
             self.log.info("checking for IP assignment on interface %s is "
                           "disabled", self.config['interface'])
-            result = True
+            return True
 
         self.log.debug("running %s", ' '.join(cmd))
         try:

--- a/local_run.sh
+++ b/local_run.sh
@@ -95,7 +95,7 @@ check_fail        = 2
 check_disabled    = false
 on_disabled       = withdraw
 ip_prefix         = fd12:aba6:57db:ffff::1/128
-ip_check_disabled = false
+ip_check_disabled = true
 EOT
 fi
 


### PR DESCRIPTION
When the aforementioned parameter has value of True, we should not run any IP address assignment check but due to a bug this wasn't happening, see the below:

```
11:56:06,834 anycast-healthchecker[3130997] DEBUG    foo.bar.com  ip_check_disabled=True:<class 'bool'>
11:56:06,834 anycast-healthchecker[3130997] DEBUG    foo.bar.com  custom_bird_reconfigure_cmd_timeout=2.0:<class 'float'>
11:56:06,835 anycast-healthchecker[3130997] INFO     foo.bar.com  checking for IP assignment on interface lo is disabled
11:56:06,835 anycast-healthchecker[3130997] DEBUG    foo.bar.com  running /sbin/ip address show dev lo to 10.52.12.1/32
11:56:06,839 anycast-healthchecker[3130997] DEBUG    foo.bar.com  10.52.12.1/32 assigned to lo interface
```

With this commit in place, we don't perform the IP address assignment check:
```
11:56:28,232 anycast-healthchecker[3132569] DEBUG    foo.bar.com  ip_check_disabled=True:<class 'bool'>
11:56:28,232 anycast-healthchecker[3132569] DEBUG    foo.bar.com  custom_bird_reconfigure_cmd_timeout=2.0:<class 'float'>
11:56:28,232 anycast-healthchecker[3132569] INFO     foo.bar.com  checking for IP assignment on interface lo is disabled
11:56:28,233 anycast-healthchecker[3132569] INFO     foo.bar.com  running curl -A anycast-healthchecker --fail --silent -o /dev/null http://10.52.12.1:8888
```

Fixes #50